### PR TITLE
Don't disable default features of `form_urlencoded`

### DIFF
--- a/facebook-fb-login-deauth-callback/Cargo.toml
+++ b/facebook-fb-login-deauth-callback/Cargo.toml
@@ -16,4 +16,4 @@ readme = "README.md"
 facebook-signed-request = { path = "../facebook-signed-request", version = "^0.1" }
 
 http = { version = "0.2", default-features = false }
-form_urlencoded = { version = "1", default-features = false }
+form_urlencoded = "1.1.0"


### PR DESCRIPTION
In https://github.com/servo/rust-url/pull/722, we would like to make the crate potentially not need `alloc` in the future, but to do so, we must now introduce a required `alloc` feature.

Since the `facebook-fb-login-deauth-callback` uses `default-features = false` on `form_urlencoded` (which previously did nothing), it will break once that change lands.